### PR TITLE
feat(gemini): update default models to Gemini 3 and 2.5 series

### DIFF
--- a/README_ja.md
+++ b/README_ja.md
@@ -1050,13 +1050,14 @@ cli:
   agents:
     shogun:
       type: gemini
-      model: gemini-2.0-flash-thinking-exp-01-21  # 将軍には思考モデルを推奨
+      model: gemini-3-pro-preview  # 将軍には最先端の推論モデルを推奨
     karo:
       type: gemini
-      model: gemini-2.0-pro-exp-02-05             # 家老には Pro モデル
+      model: gemini-3-flash-preview  # 家老には高速かつ高度な Flash-Preview
     ashigaru1:
       type: gemini
-      model: gemini-2.0-flash                     # 足軽には高速な Flash モデル
+      model: gemini-2.5-flash        # 足軽には安定した Flash モデル
+
 ```
 
 **Thinking制御**:

--- a/first_setup.sh
+++ b/first_setup.sh
@@ -656,17 +656,16 @@ capability_tiers:
   opus: { max_bloom: 6, cost_group: claude_max }
   haiku: { max_bloom: 3, cost_group: claude_max }
   # Gemini
-  gemini-2.0-flash: { max_bloom: 3, cost_group: gemini_free }
-  gemini-2.0-flash-thinking-exp-01-21: { max_bloom: 6, cost_group: gemini_free }
-  gemini-2.0-pro-exp-02-05: { max_bloom: 6, cost_group: gemini_free }
-  gemini-1.5-pro: { max_bloom: 6, cost_group: gemini_free }
-  gemini-1.5-flash: { max_bloom: 3, cost_group: gemini_free }
+  gemini-3-pro-preview: { max_bloom: 6, cost_group: gemini_free }
+  gemini-3-flash-preview: { max_bloom: 4, cost_group: gemini_free }
+  gemini-2.5-pro: { max_bloom: 5, cost_group: gemini_free }
+  gemini-2.5-flash: { max_bloom: 3, cost_group: gemini_free }
 
 # モデル選択の優先順位設定
 bloom_model_preference:
-  L1-L3: [gemini-2.0-flash, haiku]
-  L4-L5: [sonnet, gemini-1.5-pro]
-  L6: [opus, gemini-2.0-flash-thinking-exp-01-21, gemini-2.0-pro-exp-02-05]
+  L1-L3: [gemini-2.5-flash, haiku]
+  L4-L5: [sonnet, gemini-2.5-pro, gemini-3-flash-preview]
+  L6: [opus, gemini-3-pro-preview]
 
 # CLI設定（デフォルトはClaude）
 cli:

--- a/lib/cli_adapter.sh
+++ b/lib/cli_adapter.sh
@@ -292,11 +292,11 @@ get_agent_model() {
         gemini)
             # Gemini CLI用デフォルトモデル
             case "$agent_id" in
-                shogun)         echo "gemini-2.0-flash-thinking-exp-01-21" ;;
-                karo)           echo "gemini-2.0-flash" ;;
-                gunshi)         echo "gemini-2.0-pro-exp-02-05" ;;
-                ashigaru*)      echo "gemini-2.0-flash" ;;
-                *)              echo "gemini-2.0-flash" ;;
+                shogun)         echo "gemini-3-pro-preview" ;;
+                karo)           echo "gemini-3-flash-preview" ;;
+                gunshi)         echo "gemini-3-pro-preview" ;;
+                ashigaru*)      echo "gemini-2.5-flash" ;;
+                *)              echo "gemini-2.5-flash" ;;
             esac
             ;;
         *)

--- a/skills/shogun-model-list/SKILL.md
+++ b/skills/shogun-model-list/SKILL.md
@@ -101,16 +101,33 @@ Output the reference tables below directly to the user. No tool calls required.
 
 ---
 
+## Gemini CLI (Google)
+
+### Gemini Models × Bloom Capability
+
+| Model | Bloom Max | Best For | Notes |
+|-------|-----------|----------|-------|
+| `gemini-2.5-flash` | **L3** | High-volume L1-L3 tasks, stable performance | Standard workhorse for workers |
+| `gemini-3-flash-preview` | **L4** | Fast reasoning, complex analysis | High-speed preview model |
+| `gemini-2.5-pro` | **L5** | Deep analysis, code review, orchestration | Stable Pro model |
+| `gemini-3-pro-preview` | **L6** | Strategic design, complex reasoning | Highest reasoning capability; recommended for Shogun/Gunshi |
+
+---
+
 ## Capability Summary (All Models, Cross-CLI)
 
 | Model | CLI | Bloom Max | Min Subscription | Notes |
 |-------|-----|-----------|-----------------|-------|
 | `gpt-5-codex-mini` | Codex CLI | L2 | ChatGPT Plus | Lightweight, minimal quota |
+| `gemini-2.5-flash` | Gemini CLI | **L3** | Gemini Free | Stable, standard workhorse |
 | `claude-haiku-4-5-20251001` | Claude Code | **L3** | Claude Free | Best Claude cost-efficiency; SWE-bench 73.3% |
 | `gpt-5.3-codex-spark` | Codex CLI | L3 | **ChatGPT Pro** | 1000+ tok/s; Terminal-Bench 58.4% |
+| `gemini-3-flash-preview` | Gemini CLI | **L4** | Gemini Free | Fast preview reasoning |
 | `gpt-5.3-codex` | Codex CLI | L4 | ChatGPT Plus | Terminal-Bench 77.3%; 400K+ context |
-| `claude-sonnet-4-6` | Claude Code | L5 | Claude Free | $3/$15/M; SWE-bench 79.6%; 1M context; math +27pt vs Sonnet 4.5 |
+| `gemini-2.5-pro` | Gemini CLI | **L5** | Gemini Free | Stable Pro capability |
+| `claude-sonnet-4-6` | Claude Code | L5 | Claude Free | $3/$15/M; SWE-bench 79.6%; 1M context |
 | `gpt-5.1-codex-max` | Codex CLI | L5 | ChatGPT Plus | Highest Codex capability |
+| `gemini-3-pro-preview` | Gemini CLI | **L6** | Gemini Free | Highest preview reasoning; L6 capable |
 | `claude-opus-4-6` | Claude Code | L6 | Claude Pro | $5/$25/M; SWE-bench 80.8%; reserve for true L6 tasks |
 
 ---


### PR DESCRIPTION
Update default models in lib/cli_adapter.sh, first_setup.sh, and documentation to reflect the latest Gemini 3 and 2.5 series.