### PR TITLE
feat: switch default CLI to Gemini CLI for all agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@
 # Config (sample files only, no secrets)
 !config/
 !config/ntfy_auth.env.sample
+!config/settings.yaml.sample
 
 # Templates
 !templates/

--- a/config/settings.yaml.sample
+++ b/config/settings.yaml.sample
@@ -1,0 +1,54 @@
+# multi-agent-shogun 設定ファイル（サンプル）
+# 使用する際は config/settings.yaml にコピーして編集してください。
+
+# 言語設定
+language: ja
+
+# シェル設定
+shell: bash
+
+# スキル設定
+skill:
+  save_path: "~/.claude/skills/"
+  local_path: "./skills/"
+
+# ログ設定
+logging:
+  level: info
+  path: "./logs/"
+
+# Capability Tiers (Bloomレベル対応)
+capability_tiers:
+  # Claude
+  sonnet: { max_bloom: 5, cost_group: claude_max }
+  opus: { max_bloom: 6, cost_group: claude_max }
+  haiku: { max_bloom: 3, cost_group: claude_max }
+  # Gemini (Gemini CLI エイリアス/モデル名)
+  pro: { max_bloom: 6, cost_group: gemini_free }
+  flash: { max_bloom: 4, cost_group: gemini_free }
+  auto: { max_bloom: 5, cost_group: gemini_free }
+  gemini-3-pro-preview: { max_bloom: 6, cost_group: gemini_free }
+  gemini-3-flash-preview: { max_bloom: 4, cost_group: gemini_free }
+  gemini-2.5-pro: { max_bloom: 5, cost_group: gemini_free }
+  gemini-2.5-flash: { max_bloom: 3, cost_group: gemini_free }
+
+# モデル選択の優先順位設定
+bloom_model_preference:
+  L1-L3: [flash, gemini-2.5-flash, haiku]
+  L4-L5: [auto, sonnet, gemini-2.5-pro, gemini-3-flash-preview]
+  L6: [pro, opus, gemini-3-pro-preview]
+
+# CLI設定（デフォルトはGemini）
+cli:
+  default: gemini
+  agents:
+    shogun: { type: gemini, model: pro, thinking: true }
+    karo: { type: gemini, model: flash }
+    gunshi: { type: gemini, model: pro, thinking: true }
+    ashigaru1: { type: gemini, model: flash }
+    ashigaru2: { type: gemini, model: flash }
+    ashigaru3: { type: gemini, model: flash }
+    ashigaru4: { type: gemini, model: flash }
+    ashigaru5: { type: gemini, model: flash }
+    ashigaru6: { type: gemini, model: flash }
+    ashigaru7: { type: gemini, model: flash }

--- a/first_setup.sh
+++ b/first_setup.sh
@@ -667,20 +667,20 @@ bloom_model_preference:
   L4-L5: [sonnet, gemini-2.5-pro, gemini-3-flash-preview]
   L6: [opus, gemini-3-pro-preview]
 
-# CLI設定（デフォルトはClaude）
+# CLI設定（デフォルトはGemini）
 cli:
-  default: claude
+  default: gemini
   agents:
-    shogun: { type: claude, model: opus, thinking: true }
-    karo: { type: claude, model: sonnet }
-    gunshi: { type: claude, model: opus, thinking: true }
-    ashigaru1: { type: claude, model: sonnet }
-    ashigaru2: { type: claude, model: sonnet }
-    ashigaru3: { type: claude, model: sonnet }
-    ashigaru4: { type: claude, model: sonnet }
-    ashigaru5: { type: claude, model: sonnet }
-    ashigaru6: { type: claude, model: sonnet }
-    ashigaru7: { type: claude, model: sonnet }
+    shogun: { type: gemini, model: pro, thinking: true }
+    karo: { type: gemini, model: flash }
+    gunshi: { type: gemini, model: pro, thinking: true }
+    ashigaru1: { type: gemini, model: flash }
+    ashigaru2: { type: gemini, model: flash }
+    ashigaru3: { type: gemini, model: flash }
+    ashigaru4: { type: gemini, model: flash }
+    ashigaru5: { type: gemini, model: flash }
+    ashigaru6: { type: gemini, model: flash }
+    ashigaru7: { type: gemini, model: flash }
 EOF
     log_success "settings.yaml を作成しました"
 else


### PR DESCRIPTION
Change the default CLI type to 'gemini' and update all agents (shogun, karo, gunshi, ashigaru1-7) to use Gemini CLI with appropriate model aliases ('pro' for shogun/gunshi, 'flash' for karo/ashigaru). Included config/settings.yaml.sample and updated first_setup.sh.