### PR TITLE
fix(gemini): ensure Gemini CLI uses idle flag for Idle detection

### DIFF
--- a/scripts/inbox_watcher.sh
+++ b/scripts/inbox_watcher.sh
@@ -50,7 +50,7 @@ if [ "${__INBOX_WATCHER_TESTING__:-}" != "1" ]; then
 
     # Fix: CLI starts at welcome screen = idle. Create idle flag so watcher
     # doesn't false-busy deadlock waiting for a stop_hook that never fires.
-    if [[ "$CLI_TYPE" == "claude" ]]; then
+    if [[ "$CLI_TYPE" == "claude" ]] || [[ "$CLI_TYPE" == "gemini" ]]; then
         touch "${IDLE_FLAG_DIR:-/tmp}/shogun_idle_${AGENT_ID}"
         echo "[$(date)] Created initial idle flag for $AGENT_ID (CLI starts idle)" >&2
     fi
@@ -716,7 +716,7 @@ agent_is_busy() {
 
     local effective_cli
     effective_cli=$(get_effective_cli_type)
-    if [[ "$effective_cli" == "claude" ]]; then
+    if [[ "$effective_cli" == "claude" ]] || [[ "$effective_cli" == "gemini" ]]; then
         # フラグファイル方式: フラグなし=busy(return 0)、あり=idle(return 1)
         [ ! -f "${IDLE_FLAG_DIR:-/tmp}/shogun_idle_${AGENT_ID}" ]
     else

--- a/tests/unit/test_idle_flag.bats
+++ b/tests/unit/test_idle_flag.bats
@@ -280,3 +280,20 @@ YAML
     [ ! -f "$IDLE_FLAG_DIR/shogun_idle_ashigaru2" ]
     [ ! -f "$IDLE_FLAG_DIR/shogun_idle_gunshi" ]
 }
+
+# ─── T-010: Gemini CLI時にフラグファイル優先 (Thinking...回避) ───
+
+@test "T-010: agent_is_busy uses idle flag for gemini CLI even if screen has Thinking..." {
+    # Create idle flag
+    touch "$IDLE_FLAG_DIR/shogun_idle_test_idle_agent"
+
+    # Gemini CLI with "Thinking..." pane → SHOULD BE IDLE due to flag
+    run bash -c "
+        MOCK_CAPTURE_PANE='Thinking... (thought for 10s)'
+        source '$WATCHER_HARNESS'
+        LAST_CLEAR_TS=0
+        CLI_TYPE='gemini'
+        agent_is_busy
+    "
+    [ "\$status" -eq 1 ]  # 1 = idle (flag overrides Thinking... text)
+}


### PR DESCRIPTION
Gemini CLI において 'Thinking...' 状態で監視役（inbox_watcher）が割り込み、デッドロックに陥る不具合を解決。
1. scripts/inbox_watcher.sh: Gemini CLI もフラグファイル方式（shogun_idle_<id>）を優先するように修正。
2. scripts/inbox_watcher.sh: 起動直後に Gemini 用のアイドルフラグを初期作成するように修正。
3. tests/unit/test_idle_flag.bats: Thinking... 表示があってもフラグがあれば Idle と判定されることを検証するテストケース (T-010) を追加。
検証用スクリプトにて、これらの修正が正しく機能することを確認済み。