### PR TITLE
fix(inbox_watcher): ShogunのThinking...を保護し0 token異常終了を防止

### DIFF
--- a/scripts/inbox_watcher.sh
+++ b/scripts/inbox_watcher.sh
@@ -768,8 +768,10 @@ send_wakeup() {
 
     # 優先度2: Agent busy — nudge送信するとEnterが消失するためスキップ
     # Claude Code: Stop hook catches unread at turn end. Skip nudge to avoid Enter loss.
-    # Exception: shogun — ntfy must be delivered immediately regardless of busy state.
-    if agent_is_busy && [[ "$AGENT_ID" != "shogun" ]]; then
+    # Exception: shogun — while Lord's input should be prioritized, we must
+    # NOT nudge while the CLI is Thinking... to avoid context corruption (input tokens: 0).
+    # Once thinking completes, the stop hook will fire or idle detection will pick it up.
+    if agent_is_busy; then
         local busy_cli_wakeup
         busy_cli_wakeup=$(get_effective_cli_type)
         if [[ "$busy_cli_wakeup" == "claude" ]]; then
@@ -970,7 +972,7 @@ for s in data.get('specials', []):
                 clear_seen=1
                 # Busy guard: skip /clear if agent is currently processing.
                 # Sending /clear during active work destroys in-progress context.
-                if agent_is_busy && [[ "$AGENT_ID" != "shogun" ]]; then
+                if agent_is_busy; then
                     echo "[$(date)] [SKIP] Agent $AGENT_ID is busy — /clear (clear_command) deferred to next cycle" >&2
                     continue
                 fi
@@ -1020,7 +1022,7 @@ for s in data.get('specials', []):
         # Exception: shogun — ntfy must be delivered immediately.
         # Safety net: if busy detection persists for >5 min, assume false-busy (stale flag)
         # and force-create idle flag to allow nudge delivery.
-        if agent_is_busy && [[ "$AGENT_ID" != "shogun" ]]; then
+        if agent_is_busy; then
             local busy_cli
             busy_cli=$(get_effective_cli_type)
             # Stale busy safety net: if agent has been "busy" for >5 minutes with


### PR DESCRIPTION
### 修正の概要
ShogunがGemini CLIで思考中（Thinking...）にnudge（inbox通知）やCLIコマンドが割り込むことで、思考が中断されて `input token: 0` で終了（空回り）してしまう問題を解決しました。

### 変更点
- `scripts/inbox_watcher.sh` 内の Shogun 固有の busy 判定無視（例外処理）を3箇所全て削除。
- 他のエージェントと同様に、思考中（busy）は静かに待ち、思考終了後に即座に次の通知を送るように変更。

### メリット
- Shogun が思考を完遂して的確な戦略回答を行えるようになります。
- 0 token 空回りを防ぐことで、Lord（ユーザー）の再入力を減らし、実質的な応答速度（タイム・トゥ・バリュー）が向上します。