### PR TITLE
fix(setup): inboxの隔離と衝突防止を実装

### DIFF
--- a/shutsujin_departure.sh
+++ b/shutsujin_departure.sh
@@ -372,12 +372,25 @@ fi
 # inbox はLinux FSにシンボリックリンク（WSL2の/mnt/c/ではinotifywaitが動かないため）
 # macOSではfswatch使用のためシンボリックリンク不要
 if [ "$(uname -s)" != "Darwin" ]; then
-    INBOX_LINUX_DIR="$HOME/.local/share/multi-agent-shogun/inbox"
-    if [ ! -L ./queue/inbox ]; then
-        mkdir -p "$INBOX_LINUX_DIR"
-        [ -d ./queue/inbox ] && cp ./queue/inbox/*.yaml "$INBOX_LINUX_DIR/" 2>/dev/null && rm -rf ./queue/inbox
-        ln -sf "$INBOX_LINUX_DIR" ./queue/inbox
-        log_info "  └─ inbox → Linux FS ($INBOX_LINUX_DIR) にシンボリックリンク作成"
+    # プロジェクトが Windows ドライブ (/mnt/) 上にあるか判定
+    if [[ "$SCRIPT_DIR" == /mnt/* ]]; then
+        # Windows側にある場合のみ、inotifywait対策としてLinux側に固有パスで逃がす
+        PROJECT_HASH=$(echo "$SCRIPT_DIR" | md5sum | cut -c1-8)
+        INBOX_LINUX_DIR="$HOME/.local/share/multi-agent-shogun/${PROJECT_HASH}/inbox"
+        if [ ! -L ./queue/inbox ]; then
+            mkdir -p "$INBOX_LINUX_DIR"
+            [ -d ./queue/inbox ] && cp ./queue/inbox/*.yaml "$INBOX_LINUX_DIR/" 2>/dev/null && rm -rf ./queue/inbox
+            ln -sf "$INBOX_LINUX_DIR" ./queue/inbox
+            log_info "  └─ inbox → Linux FS固有領域 ($INBOX_LINUX_DIR) にシンボリックリンク作成"
+        fi
+    else
+        # Linux側（WSLネイティブ）にある場合は、そのままワークツリー内のディレクトリを使う
+        if [ -L ./queue/inbox ]; then
+            rm ./queue/inbox
+            log_info "  └─ inbox → WSLネイティブ領域のため、シンボリックリンクを解除いたした"
+        fi
+        [ -d ./queue/inbox ] || mkdir -p ./queue/inbox
+        log_info "  └─ inbox → ワークツリー内 (./queue/inbox) を直接使用いたす"
     fi
 else
     [ -d ./queue/inbox ] || mkdir -p ./queue/inbox


### PR DESCRIPTION
## 概要
複数のプロジェクト（フォルダ）を同時に起動した際、`queue/inbox` が衝突する問題を修正しました。

## 変更点
- **WSLネイティブ領域 (/home/...) の場合**: シンボリックリンクを解除し、各フォルダ内の `queue/inbox` を直接使用するように変更。
- **Windowsマウント領域 (/mnt/...) の場合**: プロジェクトパスのハッシュを用いた固有ディレクトリを Linux 側に作成し、衝突を防止。